### PR TITLE
Don't suppress the output of failures in the log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.3.2
+## In development
 
 - Provide more logging in the case of schedule failures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.2
+
+- Provide more logging in the case of schedule failures
+
 ## 2.3.1
 
 - Container image size optimisation. Reduced the final image size by 100MB

--- a/rootfs/scripts/generate-crontab.py
+++ b/rootfs/scripts/generate-crontab.py
@@ -275,7 +275,7 @@ async def make_crontab(collector, target, reference, artifact, **kwargs):
             json.dumps(script_args),
         ]
 
-        command = str(" ".join([shlex.quote(part) for part in command])) + " >/dev/null"
+        command = str(" ".join([shlex.quote(part) for part in command]))
 
         job = cron.new(command=command)
         job.dow.on(*options.dow)


### PR DESCRIPTION
This will provide more verbose details in the event a scheduled action didn't succeed. In particular, it'll list the bulbs that it was unable to reach or update.

Signed-off-by: Avi Miller <me@dje.li>